### PR TITLE
feat: use next/config to get the SENTRY_DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ This is an example showing how to use [Sentry](https://sentry.io) to catch & rep
 
 Preview the example live on [StackBlitz](http://stackblitz.com/):
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/vercel/next.js/tree/canary/examples/with-sentry)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/natterstefan/next-with-sentry)
 
 ## Deploy your own
 
 Once you have access to your [Sentry DSN](https://docs.sentry.io/product/sentry-basics/dsn-explainer/#where-to-find-your-dsn), deploy the example using [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example):
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-sentry&project-name=with-sentry&repository-name=with-sentry&env=NEXT_PUBLIC_SENTRY_DSN&envDescription=DSN%20Key%20required%20by%20Sentry&envLink=https://github.com/vercel/next.js/tree/canary/examples/with-sentry%23step-1-enable-error-tracking)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/natterstefan/next-with-sentry&project-name=next-with-sentry&repository-name=next-with-sentry&env=NEXT_PUBLIC_SENTRY_DSN&envDescription=DSN%20Key%20required%20by%20Sentry&envLink=https://github.com/natterstefan/next-with-sentry%23step-1-enable-error-tracking)
 
 Check out [Sentry’s Vercel Integration](#sentry-integration).
 
@@ -46,7 +46,7 @@ Both ways lead to having your custom config files (`next.config.js`, `sentry.cli
 
 You can deploy this app to the cloud with [Vercel](https://vercel.com?utm_source=github&utm_medium=readme&utm_campaign=next-example) ([Documentation](https://nextjs.org/docs/deployment)).
 
-#### Deploy Your Local Project
+### Deploy Your Local Project
 
 To deploy your local project to Vercel, push it to GitHub/GitLab/Bitbucket and [import to Vercel](https://vercel.com/new?utm_source=github&utm_medium=readme&utm_campaign=next-example).
 
@@ -56,7 +56,7 @@ To deploy your local project to Vercel, push it to GitHub/GitLab/Bitbucket and [
 
 Alternatively, you can deploy using our template by clicking on the Deploy button below.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/vercel/next.js/tree/canary/examples/with-sentry&project-name=with-sentry&repository-name=with-sentry&env=NEXT_PUBLIC_SENTRY_DSN&envDescription=DSN%20Key%20required%20by%20Sentry&envLink=https://github.com/vercel/next.js/tree/canary/examples/with-sentry%23step-1-enable-error-tracking)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/git/external?repository-url=https://github.com/natterstefan/next-with-sentry&project-name=next-with-sentry&repository-name=next-with-sentry&env=NEXT_PUBLIC_SENTRY_DSN&envDescription=DSN%20Key%20required%20by%20Sentry&envLink=https://github.com/natterstefan/next-with-sentry%23step-1-enable-error-tracking)
 
 ## Sentry Integration
 

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,9 @@ const withGraphql = require('next-plugin-graphql')
 
 const moduleExports = {
   future: { webpack5: true },
+  publicRuntimeConfig: {
+    dns: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+  }
 }
 
 const SentryWebpackPluginOptions = {

--- a/sentry.client.config.js
+++ b/sentry.client.config.js
@@ -3,8 +3,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
+import getConfig from 'next/config'
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+const SENTRY_DSN = getConfig().publicRuntimeConfig.dns
 
 Sentry.init({
   dsn: SENTRY_DSN,

--- a/sentry.server.config.js
+++ b/sentry.server.config.js
@@ -3,8 +3,9 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from '@sentry/nextjs'
+import getConfig from 'next/config'
 
-const SENTRY_DSN = process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN
+const SENTRY_DSN = getConfig().publicRuntimeConfig.dns
 
 Sentry.init({
   dsn: SENTRY_DSN,


### PR DESCRIPTION
This would allow changing `SENTRY_DSN` when (re)starting the app.

## Setup

Make sure you prepare your `.env.local` first.

```
# .env.local

# Sentry
# @see https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
SENTRY_DSN=""
# get the values here https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#configure-sentry-cli
SENTRY_URL="https://sentry.io/"
SENTRY_ORG="your-organisation"
SENTRY_PROJECT="your-project"
# get the auth token here https://sentry.io/settings/account/api/auth-tokens/
SENTRY_AUTH_TOKEN=""
# if you get an an error that the file could not be found, note that this is a
# false-positive error
# @see https://github.com/getsentry/sentry-docs/issues/3721
# @see https://github.com/getsentry/sentry-javascript/issues/3691#issuecomment-868377000
SENTRY_SERVER_INIT_PATH=.next/server/sentry/initServerSDK.js
```